### PR TITLE
✨ Validar boton guardar

### DIFF
--- a/src/app/views/pages/consultas/consulta/consulta.component.html
+++ b/src/app/views/pages/consultas/consulta/consulta.component.html
@@ -57,7 +57,7 @@
   <section *ngIf="!loadingDataEdicion" [formGroup]="consultaForm">
     <p><mat-checkbox formControlName="es_borrador">Guardar como borrador</mat-checkbox></p>
   </section>
-  <button mat-raised-button color="primary">Guardar</button>
+  <button mat-raised-button color="primary" [disabled]="consultaForm.invalid">Guardar</button>
 </span>
 
 </form>


### PR DESCRIPTION
El botón guardar no se habilita si no se ingresan los datos requieridos y con sus formatos